### PR TITLE
Fix TypeError: '<' not supported between instances of 'IntervalItem' …

### DIFF
--- a/zbxepics/casender/item/intervalitem.py
+++ b/zbxepics/casender/item/intervalitem.py
@@ -141,6 +141,9 @@ class IntervalItem(object):
         zm = ZabbixMetric(self.host, self.item_key, value)
         return [zm]
 
+    def __lt__(self, other):
+        return True
+
 
 class IntervalItemLast(IntervalItem):
     """a class for last interval item"""


### PR DESCRIPTION
Intervalアイテム実行時に発生していた問題（`TypeError: '<' not supported between instances of ...`）を修正しました。